### PR TITLE
feat: add auth fields to SocialPlatformConfig

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -493,8 +493,12 @@ export interface SocialPlatformConfig {
   defaultAspectRatio?: string;
   charLimit?: number;
   supportsCarousel?: boolean;
+  supportsVideo?: boolean;
+  supportedMediaKinds?: string[];
   type?: string;
   scopes?: string;
+  authenticated: boolean;
+  username: string | null;
 }
 
 export type SocialPlatformsResponse = Record<string, SocialPlatformConfig>;


### PR DESCRIPTION
## Summary

- Adds `authenticated` and `username` to `SocialPlatformConfig` type
- Adds `supportsVideo` and `supportedMediaKinds` optional fields
- `getPlatforms()` now returns the full picture — config + auth — in one call

## Depends on

- `Extra-Chill/data-machine-socials` PR (backend must return these fields first)