### PR TITLE
Add typed methods for user settings, profile, subscriptions, and artist access

### DIFF
--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -6,6 +6,21 @@ import type {
   OnboardingSubmitRequest,
   OnboardingSubmitResponse,
   LeaderboardResponse,
+  UserSettings,
+  UpdateUserSettingsRequest,
+  ChangeEmailRequest,
+  ChangeEmailResponse,
+  ChangePasswordRequest,
+  ChangePasswordResponse,
+  UserProfile,
+  UpdateUserProfileRequest,
+  UpdateUserLinksRequest,
+  UpdateUserLinksResponse,
+  UserSubscriptions,
+  UpdateSubscriptionsRequest,
+  UpdateSubscriptionsResponse,
+  RequestArtistAccessRequest,
+  RequestArtistAccessResponse,
 } from '../types';
 
 export class UsersResource extends BaseResource {
@@ -46,5 +61,53 @@ export class UsersResource extends BaseResource {
 
   unlinkArtist(userId: number, artistId: number): Promise<void> {
     return this.del(`extrachill/v1/users/${userId}/artists/${artistId}`);
+  }
+
+  // ─── Settings ────────────────────────────────────────────────────────
+
+  getSettings(): Promise<UserSettings> {
+    return this.get('extrachill/v1/users/me/settings');
+  }
+
+  updateSettings(data: UpdateUserSettingsRequest): Promise<UserSettings> {
+    return this.post('extrachill/v1/users/me/settings', data as unknown as Record<string, unknown>);
+  }
+
+  changeEmail(data: ChangeEmailRequest): Promise<ChangeEmailResponse> {
+    return this.post('extrachill/v1/users/me/email', data as unknown as Record<string, unknown>);
+  }
+
+  changePassword(data: ChangePasswordRequest): Promise<ChangePasswordResponse> {
+    return this.post('extrachill/v1/users/me/password', data as unknown as Record<string, unknown>);
+  }
+
+  // ─── Profile ─────────────────────────────────────────────────────────
+
+  getProfile(): Promise<UserProfile> {
+    return this.get('extrachill/v1/users/me/profile');
+  }
+
+  updateProfile(data: UpdateUserProfileRequest): Promise<UserProfile> {
+    return this.post('extrachill/v1/users/me/profile', data as unknown as Record<string, unknown>);
+  }
+
+  updateLinks(data: UpdateUserLinksRequest): Promise<UpdateUserLinksResponse> {
+    return this.post('extrachill/v1/users/me/links', data as unknown as Record<string, unknown>);
+  }
+
+  // ─── Subscriptions ───────────────────────────────────────────────────
+
+  getSubscriptions(): Promise<UserSubscriptions> {
+    return this.get('extrachill/v1/users/me/subscriptions');
+  }
+
+  updateSubscriptions(data: UpdateSubscriptionsRequest): Promise<UpdateSubscriptionsResponse> {
+    return this.post('extrachill/v1/users/me/subscriptions', data as unknown as Record<string, unknown>);
+  }
+
+  // ─── Artist Access Request ───────────────────────────────────────────
+
+  requestArtistAccess(data: RequestArtistAccessRequest): Promise<RequestArtistAccessResponse> {
+    return this.post('extrachill/v1/users/me/artist-access', data as unknown as Record<string, unknown>);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,127 @@ export interface LeaderboardResponse {
   pagination: LeaderboardPagination;
 }
 
+// ─── User Settings ──────────────────────────────────────────────────────────
+
+export interface UserSettings {
+  user_id: number;
+  first_name: string;
+  last_name: string;
+  display_name: string;
+  display_name_options: string[];
+  email: string;
+  pending_email: string | null;
+}
+
+export interface UpdateUserSettingsRequest {
+  first_name?: string;
+  last_name?: string;
+  display_name?: string;
+}
+
+export interface ChangeEmailRequest {
+  new_email: string;
+}
+
+export interface ChangeEmailResponse {
+  success: boolean;
+  message: string;
+  pending_email: string;
+}
+
+export interface ChangePasswordRequest {
+  current_password: string;
+  new_password: string;
+  confirm_password: string;
+}
+
+export interface ChangePasswordResponse {
+  success: boolean;
+  message: string;
+}
+
+// ─── User Profile ───────────────────────────────────────────────────────────
+
+export interface UserLink {
+  type_key: string;
+  url: string;
+  custom_label?: string;
+}
+
+export interface ArtistAccessStatus {
+  status: 'none' | 'pending' | 'approved';
+  type: string;
+  request_type?: string;
+  requested_at?: number;
+}
+
+export interface UserProfile {
+  user_id: number;
+  display_name: string;
+  username: string;
+  avatar_url: string;
+  custom_title: string;
+  bio: string;
+  local_city: string;
+  links: UserLink[];
+  link_types: Record<string, string>;
+  artist_access: ArtistAccessStatus;
+}
+
+export interface UpdateUserProfileRequest {
+  custom_title?: string;
+  bio?: string;
+  local_city?: string;
+}
+
+export interface UpdateUserLinksRequest {
+  links: UserLink[];
+}
+
+export interface UpdateUserLinksResponse {
+  success: boolean;
+  message: string;
+  user_id: number;
+  links: UserLink[];
+}
+
+// ─── User Subscriptions ─────────────────────────────────────────────────────
+
+export interface FollowedArtist {
+  artist_id: number;
+  name: string;
+  url: string;
+  email_consent: boolean;
+}
+
+export interface UserSubscriptions {
+  user_id: number;
+  followed_artists: FollowedArtist[];
+}
+
+export interface UpdateSubscriptionsRequest {
+  consented_artists: number[];
+}
+
+export interface UpdateSubscriptionsResponse {
+  success: boolean;
+  message: string;
+  user_id: number;
+}
+
+// ─── Artist Access Request ──────────────────────────────────────────────────
+
+export interface RequestArtistAccessRequest {
+  type: 'artist' | 'professional';
+}
+
+export interface RequestArtistAccessResponse {
+  success: boolean;
+  message: string;
+  user_id: number;
+  type: string;
+}
+
 // ─── Artists ─────────────────────────────────────────────────────────────────
 
 export interface Artist {


### PR DESCRIPTION
## Summary

Adds typed client methods on `client.users.*` for the new user management REST endpoints.

### New Methods

**Settings:** `getSettings()`, `updateSettings()`, `changeEmail()`, `changePassword()`
**Profile:** `getProfile()`, `updateProfile()`, `updateLinks()`
**Subscriptions:** `getSubscriptions()`, `updateSubscriptions()`
**Artist Access:** `requestArtistAccess()`

### New Types

`UserSettings`, `UserProfile`, `UserLink`, `ArtistAccessStatus`, `FollowedArtist`, `UserSubscriptions`, and request/response types for all operations.

Depends on: Extra-Chill/extrachill-api (REST routes PR)
Part of: User Management Modernization