### PR TITLE
feat!: SocialPlatformsResponse becomes ordered { platforms: SocialPlatformConfig[] }

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -607,8 +607,21 @@ export interface SocialPlatformAuthStatus {
   username: string | null;
 }
 
-export interface SocialPlatformConfig {
+export interface SocialPlatformCapability {
+  slug: string;
   label: string;
+}
+
+export interface SocialPlatformConfig {
+  /** Stable identifier (e.g. "instagram", "twitter"). Always present. */
+  slug: string;
+  label: string;
+  /** Handler type — currently always "publish" for entries returned by /platforms. */
+  type: string;
+  authenticated: boolean;
+  username: string | null;
+  /** Canonical capability list. At minimum `[{slug:'publish',label:'Publish'}]`. */
+  capabilities: SocialPlatformCapability[];
   maxImages?: number;
   aspectRatios?: string[];
   defaultAspectRatio?: string;
@@ -616,13 +629,18 @@ export interface SocialPlatformConfig {
   supportsCarousel?: boolean;
   supportsVideo?: boolean;
   supportedMediaKinds?: string[];
-  type?: string;
   scopes?: string;
-  authenticated: boolean;
-  username: string | null;
 }
 
-export type SocialPlatformsResponse = Record<string, SocialPlatformConfig>;
+/**
+ * Response shape for `GET /datamachine/v1/socials/platforms`.
+ *
+ * Server returns publish handlers only, sorted authenticated-first then
+ * alphabetically by label. Render in array order.
+ */
+export interface SocialPlatformsResponse {
+  platforms: SocialPlatformConfig[];
+}
 
 export interface SocialImageInput {
   url: string;


### PR DESCRIPTION
## Summary

Mirrors the breaking REST contract change in [data-machine-socials#131](https://github.com/Extra-Chill/data-machine-socials/pull/131). The `/platforms` endpoint now returns an ordered array under a `{ platforms: [...] }` envelope with `slug` and canonical `capabilities` always present on every entry. This PR updates the typed wrapper to match.

## Changes

### Before

```ts
export interface SocialPlatformConfig {
  label: string;
  authenticated: boolean;
  username: string | null;
  // ... no slug, no capabilities
}

export type SocialPlatformsResponse = Record<string, SocialPlatformConfig>;
```

### After

```ts
export interface SocialPlatformCapability {
  slug: string;
  label: string;
}

export interface SocialPlatformConfig {
  slug: string;                              // ← now required
  label: string;
  type: string;                              // ← now required
  authenticated: boolean;
  username: string | null;
  capabilities: SocialPlatformCapability[];  // ← now required, canonical shape
  // ... rest of fields unchanged
}

export interface SocialPlatformsResponse {
  platforms: SocialPlatformConfig[];         // ← array, ordered
}
```

`SocialsResource.getPlatforms()` signature is unchanged on disk (`Promise<SocialPlatformsResponse>`); only the underlying type shape changed.

## Why

- **`platforms` array** — server controls display order (authenticated-first then A-Z), clients render in iteration order. No more relying on JS object key insertion order.
- **`slug` always present** — clients no longer reconstruct it from object keys.
- **Canonical `capabilities` shape** — kills the `string[]` legacy fallback in client code (server-side `normalize_capabilities` handles legacy handler output before serialization).

## Coordinated rollout

This is **PR B** of a 3-PR cluster:

1. [data-machine-socials#131](https://github.com/Extra-Chill/data-machine-socials/pull/131) — REST contract
2. **B (this PR)** — typed wrapper
3. extrachill-studio (next) — consumer

Studio + any other api-client consumer will break against the new server response until C lands. Order: A → B → C, deploy in same order.

## Test plan

- ✅ `npx tsc --noEmit` clean
- ✅ `npm run build` clean (CJS + ESM + DTS bundles)
- ⏳ Studio sidebar regression check after PR C deploys