### PR TITLE
feat: NetworkMediaResource for /extrachill/v1/network-media

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -28,6 +28,7 @@ import { CommunityResource } from './resources/community';
 import { EventsResource } from './resources/events';
 import { AnalyticsResource } from './resources/analytics';
 import { MediaResource } from './resources/media';
+import { NetworkMediaResource } from './resources/network-media';
 import { ShopResource } from './resources/shop';
 import { UsersResource } from './resources/users';
 import { AdminResource } from './resources/admin';
@@ -44,6 +45,7 @@ export class ExtraChillClient {
   readonly events: EventsResource;
   readonly analytics: AnalyticsResource;
   readonly media: MediaResource;
+  readonly networkMedia: NetworkMediaResource;
   readonly shop: ShopResource;
   readonly users: UsersResource;
   readonly admin: AdminResource;
@@ -60,6 +62,7 @@ export class ExtraChillClient {
     this.events = new EventsResource(transport);
     this.analytics = new AnalyticsResource(transport);
     this.media = new MediaResource(transport);
+    this.networkMedia = new NetworkMediaResource(transport);
     this.shop = new ShopResource(transport);
     this.users = new UsersResource(transport);
     this.admin = new AdminResource(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export { CommunityResource } from './resources/community';
 export { EventsResource } from './resources/events';
 export { AnalyticsResource } from './resources/analytics';
 export { MediaResource } from './resources/media';
+export { NetworkMediaResource } from './resources/network-media';
 export { ShopResource } from './resources/shop';
 export { UsersResource } from './resources/users';
 export { AdminResource } from './resources/admin';
@@ -57,3 +58,4 @@ export { SocialsResource } from './resources/socials';
 // Resource param types
 export type { CalendarParams } from './resources/events';
 export type { AnalyticsEventsParams } from './resources/analytics';
+export type { NetworkMediaListParams } from './resources/network-media';

--- a/src/resources/network-media.ts
+++ b/src/resources/network-media.ts
@@ -1,0 +1,47 @@
+import { BaseResource } from './base';
+import type { NetworkMediaItem, NetworkMediaListResponse } from '../types';
+
+export interface NetworkMediaListParams {
+  media_type?: 'image' | 'video' | 'audio';
+  search?: string;
+  per_page?: number;
+  page?: number;
+}
+
+/**
+ * Network media library access.
+ *
+ * Phase 1 of the network-wide unified media library
+ * (extrachill-multisite#2) — currently scoped to the main editorial site
+ * (blog 1). Use this from any subsite to browse and upload to the main
+ * media library.
+ */
+export class NetworkMediaResource extends BaseResource {
+  /** List attachments from the main media library. */
+  list(params: NetworkMediaListParams = {}): Promise<NetworkMediaListResponse> {
+    const query = this.buildQuery({
+      media_type: params.media_type,
+      search: params.search,
+      per_page: params.per_page,
+      page: params.page,
+    });
+    return this.get(`extrachill/v1/network-media${query}`);
+  }
+
+  /** Upload a file into the main media library. */
+  upload(formData: FormData): Promise<NetworkMediaItem> {
+    return this.postFormData('extrachill/v1/network-media', formData);
+  }
+
+  /**
+   * Helper to build a FormData payload for upload.
+   * Browser/RN compatible — caller hands in a File or Blob.
+   */
+  buildUploadForm(file: Blob | File, opts: { title?: string; alt?: string } = {}): FormData {
+    const formData = new FormData();
+    formData.append('file', file);
+    if (opts.title) formData.append('title', opts.title);
+    if (opts.alt) formData.append('alt', opts.alt);
+    return formData;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -523,6 +523,38 @@ export interface MediaUploadResponse {
   mime_type: string;
 }
 
+// ─── Network Media ───────────────────────────────────────────────────────────
+
+/**
+ * Canonical attachment shape returned by `/extrachill/v1/network-media`.
+ *
+ * `sourceId` is `"<blog_id>:<attachment_id>"` so future cross-site phases
+ * can disambiguate IDs that collide across sites. Today blog_id is always 1.
+ */
+export interface NetworkMediaItem {
+  id: number;
+  blog_id: number;
+  sourceId: string;
+  url: string;
+  previewUrl: string;
+  title: string;
+  alt: string;
+  caption: string;
+  mime_type: string;
+  media_type: string;
+  date: string;
+  width: number;
+  height: number;
+}
+
+export interface NetworkMediaListResponse {
+  items: NetworkMediaItem[];
+  total: number;
+  total_pages: number;
+  page: number;
+  per_page: number;
+}
+
 // ─── Shop ────────────────────────────────────────────────────────────────────
 
 export interface ShopProduct {


### PR DESCRIPTION
## Summary

Adds typed wrapper for the \`/extrachill/v1/network-media\` REST endpoint introduced in [extrachill-api#21](https://github.com/Extra-Chill/extrachill-api/pull/21). Consumers access it as \`client.networkMedia.list(...)\` and \`client.networkMedia.upload(...)\`.

## Usage

\`\`\`ts
import { ExtraChillClient } from '@extrachill/api-client';

const result = await client.networkMedia.list({
  media_type: 'image',
  search: 'pour house',
  per_page: 20,
});

// result.items is NetworkMediaItem[]
// result.total, result.total_pages, result.page, result.per_page

// Upload
const formData = client.networkMedia.buildUploadForm(file, {
  title: 'Photo title',
  alt: 'Alt text',
});
const item = await client.networkMedia.upload(formData);
\`\`\`

## Types added

- \`NetworkMediaItem\` — canonical attachment shape (id, blog_id, sourceId, url, previewUrl, title, alt, caption, mime_type, media_type, date, width, height)
- \`NetworkMediaListResponse\` — list envelope with pagination metadata
- \`NetworkMediaListParams\` — list query params

## Coordinated rollout

This is **PR 3 of 4**. Depends on PRs 1+2 being deployed for the endpoint to exist.

1. extrachill-multisite — abilities
2. extrachill-api — REST route
3. **extrachill-api-client** (this PR) — typed resource
4. extrachill-studio — Socials tab consumer

Will be published as a minor bump (additive feature, no breaking change) — likely 0.5.0.

## Test plan

- ✅ \`npm run typecheck\` clean
- ✅ \`npm run build\` clean (CJS + ESM + DTS)
- ⏳ Studio integration after PR 4 deploys against the new types