### PR TITLE
feat(socials): normalize async publish contract and add job status types

### DIFF
--- a/src/resources/socials.ts
+++ b/src/resources/socials.ts
@@ -1,10 +1,11 @@
 import { BaseResource } from './base';
 import type {
+  SocialJobStatusResponse,
   SocialMediaUploadResponse,
   SocialPlatformAuthStatus,
   SocialPlatformsResponse,
+  SocialPublishJobResponse,
   SocialPublishRequest,
-  SocialPublishResponse,
   SocialStatusEntry,
 } from '../types';
 
@@ -17,8 +18,25 @@ export class SocialsResource extends BaseResource {
     return this.get('datamachine/v1/socials/platforms');
   }
 
-  crossPost(data: SocialPublishRequest): Promise<SocialPublishResponse> {
+  /**
+   * Schedule a social cross-post job.
+   *
+   * Returns immediately with a job ID. The actual publishing happens
+   * asynchronously via Action Scheduler. Poll {@link getJobStatus} to
+   * check completion and retrieve per-platform results.
+   */
+  crossPost(data: SocialPublishRequest): Promise<SocialPublishJobResponse> {
     return this.post('datamachine/v1/socials/post', data as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Get the status and results of a social cross-post job.
+   *
+   * @param jobId - The `job_id` returned by {@link crossPost}.
+   * @returns Job record including `engine_data.results` when completed.
+   */
+  getJobStatus(jobId: number): Promise<SocialJobStatusResponse> {
+    return this.get(`datamachine/v1/socials/jobs/${jobId}`);
   }
 
   uploadCroppedMedia(formData: FormData): Promise<SocialMediaUploadResponse> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -694,10 +694,86 @@ export interface SocialPublishResult {
   error?: string;
 }
 
-export interface SocialPublishResponse {
+/**
+ * Response from `POST /datamachine/v1/socials/post`.
+ *
+ * The endpoint schedules an async job — it does NOT publish synchronously.
+ * Use `getJobStatus(job_id)` to poll for completion and final results.
+ */
+export interface SocialPublishJobResponse {
   success: boolean;
-  results: SocialPublishResult[];
-  errors?: string[] | null;
+  job_id: number;
+  status: 'pending';
+}
+
+/**
+ * @deprecated Use `SocialPublishJobResponse` instead.
+ * `crossPost()` schedules an async job and returns `{ success, job_id, status }`,
+ * not a synchronous result set. This alias is kept for backward compatibility
+ * but will be removed in a future major version.
+ */
+export type SocialPublishResponse = SocialPublishJobResponse;
+
+/**
+ * Possible statuses for a Data Machine job.
+ */
+export type SocialJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+/**
+ * Per-platform result from a completed social cross-post job.
+ * Found in `engine_data.results` after the job finishes.
+ */
+export interface SocialJobPlatformResult {
+  platform: string;
+  success: boolean;
+  platform_post_id?: string;
+  platform_url?: string;
+  error?: string;
+}
+
+/**
+ * Engine data stored on a completed social cross-post job.
+ */
+export interface SocialJobEngineData {
+  task_type?: string;
+  post_id?: number | null;
+  platforms?: string[];
+  results?: SocialJobPlatformResult[];
+  log?: Array<{
+    platform: string;
+    success: boolean;
+    post_id?: string;
+    url?: string;
+    error?: string;
+    timestamp?: string;
+  }>;
+  success_count?: number;
+  failure_count?: number;
+  error?: string;
+}
+
+/**
+ * Single job record returned by `GET /datamachine/v1/socials/jobs/{job_id}`.
+ */
+export interface SocialJobRecord {
+  job_id: number;
+  user_id: number;
+  status: SocialJobStatus;
+  label?: string | null;
+  engine_data?: SocialJobEngineData | null;
+  created_at: string;
+  completed_at?: string | null;
+  created_at_display?: string;
+  completed_at_display?: string;
+}
+
+/**
+ * Response from `GET /datamachine/v1/socials/jobs/{job_id}`.
+ */
+export interface SocialJobStatusResponse {
+  success: boolean;
+  jobs: SocialJobRecord[];
+  total: number;
 }
 
 export interface SocialMediaUploadResponse {


### PR DESCRIPTION
## Summary

- **`crossPost()` return type** updated from the incorrect `SocialPublishResponse` (which claimed synchronous `results[]`) to **`SocialPublishJobResponse`** (`{ success, job_id, status: 'pending' }`), matching what `POST /datamachine/v1/socials/post` actually returns.
- **`getJobStatus(jobId)`** method added to `SocialsResource` for `GET /datamachine/v1/socials/jobs/{job_id}`, enabling consumers to poll for completion and retrieve per-platform results.
- **New types** for the full async job lifecycle: `SocialPublishJobResponse`, `SocialJobStatus`, `SocialJobPlatformResult`, `SocialJobEngineData`, `SocialJobRecord`, `SocialJobStatusResponse`.

## Backward compatibility

`SocialPublishResponse` is preserved as a **deprecated type alias** → `SocialPublishJobResponse`. Existing imports compile, but the shape no longer has `.results` or `.errors` (those fields never existed on the real server response).

## Downstream changes needed (extrachill-studio)

In `extrachill-studio/src/blocks/studio/tabs/socials/publish/index.ts`:

1. `SocialPublishResponse` → rename import to `SocialPublishJobResponse`
2. Stop reading `response.results` / `response.errors` from `crossPost()` — use `response.job_id` + `getJobStatus()` instead
3. Rework `platformResult` to source from job status polling, not the initial schedule response

## Server-side note

`GET /datamachine/v1/socials/jobs/{job_id}` has a slug mismatch bug (`datamachine/jobs-get` vs `datamachine/get-jobs`) — currently returns 500. Needs a fix in `data-machine-socials` before `getJobStatus()` works end-to-end.

## Checks

- `tsc --noEmit` ✅
- `tsup` build ✅
- No test suite in this repo