### PR TITLE
feat: add social job wait helper

### DIFF
--- a/src/resources/socials.ts
+++ b/src/resources/socials.ts
@@ -1,6 +1,8 @@
 import { BaseResource } from './base';
 import type {
+  SocialJobRecord,
   SocialJobStatusResponse,
+  SocialJobWaitOptions,
   SocialMediaUploadResponse,
   SocialPlatformAuthStatus,
   SocialPlatformsResponse,
@@ -8,6 +10,9 @@ import type {
   SocialPublishRequest,
   SocialStatusEntry,
 } from '../types';
+
+const DEFAULT_JOB_POLL_INTERVAL_MS = 3000;
+const DEFAULT_JOB_TIMEOUT_MS = 120000;
 
 export class SocialsResource extends BaseResource {
   getAuthStatus(): Promise<SocialPlatformAuthStatus[]> {
@@ -39,11 +44,79 @@ export class SocialsResource extends BaseResource {
     return this.get(`datamachine/v1/socials/jobs/${jobId}`);
   }
 
+  /**
+   * Wait for a social cross-post job to reach a terminal state.
+   *
+   * This is transport-agnostic client-side orchestration over the Socials job
+   * endpoint. It works in WordPress blocks, mobile apps, and Node consumers.
+   *
+   * @param jobId - The `job_id` returned by {@link crossPost}.
+   * @param options - Polling interval, timeout, abort signal, and status hook.
+   * @returns The completed job record, including `engine_data.results`.
+   * @throws When the job fails, times out, cannot be found, or is aborted.
+   */
+  async waitForCrossPostJob(jobId: number, options: SocialJobWaitOptions = {}): Promise<SocialJobRecord> {
+    const intervalMs = options.intervalMs ?? DEFAULT_JOB_POLL_INTERVAL_MS;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_JOB_TIMEOUT_MS;
+    const startedAt = Date.now();
+
+    while (true) {
+      if (options.signal?.aborted) {
+        throw new Error('Social job wait aborted');
+      }
+
+      const response = await this.getJobStatus(jobId);
+      const job = response.jobs?.[0];
+
+      if (!job) {
+        throw new Error(`Social job ${jobId} was not found`);
+      }
+
+      options.onStatus?.(job);
+
+      if (job.status === 'completed') {
+        return job;
+      }
+
+      if (typeof job.status === 'string' && job.status.startsWith('failed')) {
+        const reason = job.engine_data?.error || job.status.replace(/^failed:?\s*/, '') || `Social job ${jobId} failed`;
+        throw new Error(reason);
+      }
+
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(`Timed out waiting for social job ${jobId}`);
+      }
+
+      await this.delay(intervalMs, options.signal);
+    }
+  }
+
   uploadCroppedMedia(formData: FormData): Promise<SocialMediaUploadResponse> {
     return this.postFormData('datamachine/v1/socials/media/crop', formData);
   }
 
   getPostStatus(postId: number): Promise<SocialStatusEntry[]> {
     return this.get(`datamachine/v1/socials/status/${postId}`);
+  }
+
+  private delay(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new Error('Social job wait aborted'));
+        return;
+      }
+
+      const timeout = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+
+      const onAbort = () => {
+        clearTimeout(timeout);
+        reject(new Error('Social job wait aborted'));
+      };
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -717,7 +717,7 @@ export type SocialPublishResponse = SocialPublishJobResponse;
 /**
  * Possible statuses for a Data Machine job.
  */
-export type SocialJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
+export type SocialJobStatus = 'pending' | 'processing' | 'completed' | 'failed' | (string & {});
 
 /**
  * Per-platform result from a completed social cross-post job.
@@ -774,6 +774,20 @@ export interface SocialJobStatusResponse {
   success: boolean;
   jobs: SocialJobRecord[];
   total: number;
+}
+
+/**
+ * Options for waiting on a social cross-post job from browser, mobile, or Node.
+ */
+export interface SocialJobWaitOptions {
+  /** Delay between status checks. Defaults to 3000 ms. */
+  intervalMs?: number;
+  /** Maximum time to wait before rejecting. Defaults to 120000 ms. */
+  timeoutMs?: number;
+  /** Abort signal for cancelling an in-flight wait. */
+  signal?: AbortSignal;
+  /** Called after each successful status response. */
+  onStatus?: (job: SocialJobRecord) => void;
 }
 
 export interface SocialMediaUploadResponse {


### PR DESCRIPTION
## Summary
- Add `socials.waitForCrossPostJob(jobId, options)` as a transport-agnostic polling helper for web/mobile/Node clients
- Add `SocialJobWaitOptions` with interval, timeout, abort signal, and `onStatus` callback
- Widen `SocialJobStatus` to allow Data Machine's `failed:*` status strings

## Checks
- `npm run typecheck`
- `npm run build`

## Notes
This helper wraps the existing Socials job endpoint (`GET /datamachine/v1/socials/jobs/{job_id}`) and keeps polling semantics out of UI consumers like Studio.