### PR TITLE
feat: broaden SocialImageInput with alt and title metadata

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -676,6 +676,17 @@ export interface SocialPlatformsResponse {
 
 export interface SocialImageInput {
   url: string;
+  /**
+   * Alt text for accessibility and platforms that surface it (Bluesky,
+   * Twitter, Threads). Optional — external URLs pasted into composers may
+   * not have associated metadata.
+   */
+  alt?: string;
+  /**
+   * Human-readable title or filename. Optional — used by clients for
+   * tooltips and aria-labels; servers may ignore it.
+   */
+  title?: string;
 }
 
 export interface SocialPublishRequest {


### PR DESCRIPTION
## Summary

Adds optional `alt` and `title` fields to `SocialImageInput` so consumers can pass per-image accessibility metadata to platforms that support it (Bluesky, Twitter, Threads).

```ts
export interface SocialImageInput {
  url: string;
  alt?: string;
  title?: string;
}
```

Both fields optional — external URLs pasted into composers won't have metadata, but media-library selections will. Server already tolerates extra fields; this just unlocks the typed path.

## Why

Discovered during Extra-Chill/extrachill-studio#39 / PR #45 — the publish pane just landed support for selecting images with alt/title from the network media library, but had to use a TypeScript cast at the call site to send `alt` to the server because the upstream type only declared `{ url: string }`. This PR removes the need for that cast.

## Verification

- `npx tsc --noEmit` passes
- `npm run build` produces clean ESM + CJS + DTS outputs
- Inspected `dist/index.d.ts` — type emits with both fields optional and JSDoc preserved

## Closes

- Closes Extra-Chill/extrachill-api-client#11

## Follow-ups

Once this ships and `extrachill-studio` upgrades to the new version, a small follow-up PR can drop the cast at `src/blocks/studio/tabs/socials/publish/index.ts` line ~237.