### PR TITLE
feat: add SocialPlatformConfig.preview type for #140

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -644,6 +644,24 @@ export interface SocialPlatformCapability {
   label: string;
 }
 
+/**
+ * Preview shape declared by each social platform handler.
+ *
+ * Tells clients how to render a post preview for the platform without any
+ * per-platform branching — the client renders whatever shape the server
+ * declares. The server always populates this field; handlers that don't
+ * declare it get a generic feed-shaped default applied server-side
+ * (`aspectRatio: 'native'`, `captionPosition: 'above'`, `previewSurface: 'feed'`).
+ */
+export interface SocialPlatformPreview {
+  /** How images are framed in the preview. */
+  aspectRatio: '1:1' | '4:5' | '16:9' | 'native';
+  /** Where the caption renders relative to media. */
+  captionPosition: 'above' | 'below' | 'overlay';
+  /** Visual chrome around the preview. */
+  previewSurface: 'card' | 'feed' | 'square';
+}
+
 export interface SocialPlatformConfig {
   /** Stable identifier (e.g. "instagram", "twitter"). Always present. */
   slug: string;
@@ -662,6 +680,14 @@ export interface SocialPlatformConfig {
   supportsVideo?: boolean;
   supportedMediaKinds?: string[];
   scopes?: string;
+  /**
+   * Preview-shape hints for client-side post preview rendering.
+   *
+   * Optional on the type for backwards compat with older DM-Socials installs
+   * that pre-date this field. Modern DM-Socials (>= 0.x with #140 merged)
+   * always emits it.
+   */
+  preview?: SocialPlatformPreview;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds the TypeScript type surface for `SocialPlatformConfig.preview`, the new server-declared preview shape introduced in [data-machine-socials#141](https://github.com/Extra-Chill/data-machine-socials/pull/141) (issue [Extra-Chill/data-machine-socials#140](https://github.com/Extra-Chill/data-machine-socials/issues/140)).

## Changes

- New `SocialPlatformPreview` interface in `src/types.ts` with three fields:
  - `aspectRatio: '1:1' | '4:5' | '16:9' | 'native'`
  - `captionPosition: 'above' | 'below' | 'overlay'`
  - `previewSurface: 'card' | 'feed' | 'square'`
- Optional `preview?: SocialPlatformPreview` field on `SocialPlatformConfig`.
- `SocialPlatformPreview` is auto-exported via `export * from './types'` in `src/index.ts`.

## Why optional on the type

Modern DM-Socials (>= the version that ships [data-machine-socials#141](https://github.com/Extra-Chill/data-machine-socials/pull/141)) **always emits** `preview` server-side — the REST layer applies a generic feed-shaped default for handlers that don't declare it. So at runtime, consumers can rely on it being present once both PRs are deployed.

The TypeScript field is marked `preview?:` (optional) anyway, so consumers building against older DM-Socials installs that pre-date the field still typecheck cleanly. This avoids a hard breaking change on the client side and lets Studio gracefully degrade if it ever runs against a stale server.

## Companion PR — must merge together

- **DM-Socials**: https://github.com/Extra-Chill/data-machine-socials/pull/141 — declares the field on each handler and adds the server-side default.

Downstream consumers (extrachill-studio#43, #44 — PostPreview primitive) are unblocked once both merge.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` produces `dist/` without errors
- [x] `SocialPlatformPreview` and the new `preview?:` field appear in `dist/index.d.ts` (confirmed via grep on the built artifact)

## Constraints

- No version bump — homeboy owns version targets at release time.
- No CHANGELOG.md edit — homeboy owns the changelog.
- Single conventional commit (`feat:`).

Refs: Extra-Chill/data-machine-socials#140